### PR TITLE
Bump HDK to 0.0.104

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = "z"
 opt-level = "z"
 
 [dependencies]
-hdk = "0.0.103"
+hdk = "0.0.104"
 
 #derive_more = "0"
 serde = "1"

--- a/tests/test_zome/Cargo.toml
+++ b/tests/test_zome/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = "z"
 opt-level = "z"
 
 [dependencies]
-hdk = "0.0.103"
+hdk = "0.0.104"
 
 #derive_more = "0"
 serde = "*"

--- a/tests/test_zome/default.nix
+++ b/tests/test_zome/default.nix
@@ -8,9 +8,9 @@ let
     holochainVersionId = "custom";
 
     holochainVersion = {
-      rev = "f3d17d993ad8d988402cc01d73a0095484efbabb";
-      sha256 = "1z0y1bl1j2cfv4cgr4k7y0pxnkbiv5c0xv89y8dqnr32vli3bld7";
-      cargoSha256 = "sha256:1rf8vg832qyymw0a4x247g0iikk6kswkllfrd5fqdr0qgf9prc31";
+      rev = "d003eb7a45f1d7125c4701332202761721793d68";
+      sha256 = "0qxadszm2a7807w49kfbj7cx6lr31qryxcyd2inyv7q5j7qbanf2";
+      cargoSha256 = "sha256:129wicin99kmxb2qwhll8f4q78gviyp73hrkm6klpkql6810y3jy";
       bins = {
         holochain = "holochain";
         hc = "hc";
@@ -18,8 +18,8 @@ let
       };
 
       lairKeystoreHashes = {
-        sha256 = "1jiz9y1d4ybh33h1ly24s7knsqyqjagsn1gzqbj1ngl22y5v3aqh";
-        cargoSha256 = "sha256:0agykcl7ysikssfwkjgb3hfw6xl0slzy38prc4rnzvagm5wd1jjv";
+        sha256 = "0khg5w5fgdp1sg22vqyzsb2ri7znbxiwl7vr2zx6bwn744wy2cyv";
+        cargoSha256 = "sha256:1lm8vrxh7fw7gcir9lq85frfd0rdcca9p7883nikjfbn21ac4sn4";
       };
     };
     holochainOtherDepsNames = ["lair-keystore"];


### PR DESCRIPTION
This branch is already used in release 0.0.13 of Social-Context that I've just published.
I'm bumping HC in ad4m-executor to 104 and need all languages updated because of breaking changes.