### PR TITLE
Bump HDK to 0.0.108

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = "z"
 opt-level = "z"
 
 [dependencies]
-hdk = "0.0.107"
+hdk = "0.0.108"
 
 #derive_more = "0"
 serde = "1"

--- a/tests/test_zome/Cargo.toml
+++ b/tests/test_zome/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = "z"
 opt-level = "z"
 
 [dependencies]
-hdk = "0.0.107"
+hdk = "0.0.108"
 
 #derive_more = "0"
 serde = "*"

--- a/tests/test_zome/default.nix
+++ b/tests/test_zome/default.nix
@@ -8,9 +8,9 @@ let
     holochainVersionId = "custom";
 
     holochainVersion = {
-      rev = "221f3424a919224dcf1950d1059e8b88aba08f7b";
-      sha256 = "1m5clhh0xpr4ajdbybxjqc5vblkd30lsfb1sac4zbzxjrnpp5iki";
-      cargoSha256 = "175b76j31sls0gj08imchwnk7n4ylsxlc1bm58zrhfmq62hcchb1";
+      rev = "cad04aec3fb5f137b2d224ab29dcc204af7b9821";
+      sha256 = "1p9rqd2d2wlyzc214ia93b1f18fgqspmza863q4hrz9ba6xigzjs";
+      cargoSha256 = "sha256:0p4m8ckbd7v411wgh14p0iz4dwi84i3cha5m1zgnqlln0wkqsb0f";
       bins = {
         holochain = "holochain";
         hc = "hc";


### PR DESCRIPTION
This branch is already used in release 0.0.15 of Social-Context that I've just published.