### PR TITLE
fix: replace deprecated chrono methods

### DIFF
--- a/src/convertions.rs
+++ b/src/convertions.rs
@@ -144,11 +144,11 @@ impl TryInto<NaiveDateTime> for WrappedPath {
     fn try_into(self) -> Result<NaiveDateTime, Self::Error> {
         let data = self.0;
         let path_comps: Vec<Component> = data.into();
-        let nd = NaiveDate::from_ymd(
+        let nd = NaiveDate::from_ymd_opt(
             get_time_index_from_components_strict(&path_comps, 1)?.0 as i32,
             get_time_index_from_components(&path_comps, 2)?.0,
             get_time_index_from_components(&path_comps, 3)?.0,
-        );
+        ).unwrap();
         //Get the path time components that are optionally present
         let hour = if INDEX_DEPTH.contains(&IndexType::Hour) {
             Some(get_time_index_from_components(&path_comps, 4)?.0)
@@ -165,11 +165,11 @@ impl TryInto<NaiveDateTime> for WrappedPath {
         } else {
             None
         };
-        let ndt = nd.and_hms(
+        let ndt = nd.and_hms_opt(
             hour.unwrap_or(1) as u32,
             min.unwrap_or(1) as u32,
             second.unwrap_or(1) as u32,
-        );
+        ).unwrap();
         Ok(ndt)
     }
 }

--- a/src/impl_utils.rs
+++ b/src/impl_utils.rs
@@ -28,11 +28,11 @@ impl std::fmt::Debug for Index {
         debug_struct.field("diff", &self.until.sub(self.from));
         debug_struct.field(
             "timestamp",
-            &NaiveDateTime::from_timestamp(self.from.as_secs() as i64, self.from.subsec_nanos()),
+            &NaiveDateTime::from_timestamp_opt(self.from.as_secs() as i64, self.from.subsec_nanos()).unwrap(),
         );
         debug_struct.field(
             "timestamp_until",
-            &NaiveDateTime::from_timestamp(self.until.as_secs() as i64, self.until.subsec_nanos()),
+            &NaiveDateTime::from_timestamp_opt(self.until.as_secs() as i64, self.until.subsec_nanos()).unwrap(),
         );
         debug_struct.finish()
     }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -61,7 +61,7 @@ where
 {
     //Running with the asumption here that sys_time is always UTC
     let now = sys_time()?.as_seconds_and_nanos();
-    let now = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now.0, now.1), Utc);
+    let now = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(now.0, now.1).unwrap(), Utc);
 
     //Create current time path
     let mut time_path = vec![Component::try_from(

--- a/src/search.rs
+++ b/src/search.rs
@@ -12,30 +12,30 @@ pub(crate) fn get_naivedatetime(
 ) -> Option<(NaiveDateTime, NaiveDateTime)> {
     match index_type {
         IndexType::Year => Some((
-            NaiveDate::from_ymd(from.year(), 1, 1).and_hms(1, 1, 1),
-            NaiveDate::from_ymd(until.year(), 1, 1).and_hms(1, 1, 1),
+            NaiveDate::from_ymd_opt(from.year(), 1, 1).unwrap().and_hms_opt(1, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(until.year(), 1, 1).unwrap().and_hms_opt(1, 1, 1).unwrap(),
         )),
         IndexType::Month => Some((
-            NaiveDate::from_ymd(from.year(), from.month(), 1).and_hms(1, 1, 1),
-            NaiveDate::from_ymd(until.year(), until.month(), 1).and_hms(1, 1, 1),
+            NaiveDate::from_ymd_opt(from.year(), from.month(), 1).unwrap().and_hms_opt(1, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(until.year(), until.month(), 1).unwrap().and_hms_opt(1, 1, 1).unwrap(),
         )),
         IndexType::Day => Some((
-            NaiveDate::from_ymd(from.year(), from.month(), from.day()).and_hms(1, 1, 1),
-            NaiveDate::from_ymd(until.year(), until.month(), until.day()).and_hms(1, 1, 1),
+            NaiveDate::from_ymd_opt(from.year(), from.month(), from.day()).unwrap().and_hms_opt(1, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(until.year(), until.month(), until.day()).unwrap().and_hms_opt(1, 1, 1).unwrap(),
         )),
         IndexType::Hour => {
             if INDEX_DEPTH.contains(&index_type) {
                 Some((
-                    NaiveDate::from_ymd(from.year(), from.month(), from.day()).and_hms(
+                    NaiveDate::from_ymd_opt(from.year(), from.month(), from.day()).unwrap().and_hms_opt(
                         from.hour(),
                         1,
                         1,
-                    ),
-                    NaiveDate::from_ymd(until.year(), until.month(), until.day()).and_hms(
+                    ).unwrap(),
+                    NaiveDate::from_ymd_opt(until.year(), until.month(), until.day()).unwrap().and_hms_opt(
                         until.hour(),
                         1,
                         1,
-                    ),
+                    ).unwrap(),
                 ))
             } else {
                 None
@@ -44,16 +44,16 @@ pub(crate) fn get_naivedatetime(
         IndexType::Minute => {
             if INDEX_DEPTH.contains(&index_type) {
                 Some((
-                    NaiveDate::from_ymd(from.year(), from.month(), from.day()).and_hms(
+                    NaiveDate::from_ymd_opt(from.year(), from.month(), from.day()).unwrap().and_hms_opt(
                         from.hour(),
                         from.minute(),
                         1,
-                    ),
-                    NaiveDate::from_ymd(until.year(), until.month(), until.day()).and_hms(
+                    ).unwrap(),
+                    NaiveDate::from_ymd_opt(until.year(), until.month(), until.day()).unwrap().and_hms_opt(
                         until.hour(),
                         until.minute(),
                         1,
-                    ),
+                    ).unwrap(),
                 ))
             } else {
                 None
@@ -62,16 +62,16 @@ pub(crate) fn get_naivedatetime(
         IndexType::Second => {
             if INDEX_DEPTH.contains(&index_type) {
                 Some((
-                    NaiveDate::from_ymd(from.year(), from.month(), from.day()).and_hms(
+                    NaiveDate::from_ymd_opt(from.year(), from.month(), from.day()).unwrap().and_hms_opt(
                         from.hour(),
                         from.minute(),
                         from.second(),
-                    ),
-                    NaiveDate::from_ymd(until.year(), until.month(), until.day()).and_hms(
+                    ).unwrap(),
+                    NaiveDate::from_ymd_opt(until.year(), until.month(), until.day()).unwrap().and_hms_opt(
                         until.hour(),
                         until.minute(),
                         until.second(),
-                    ),
+                    ).unwrap(),
                 ))
             } else {
                 None

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,7 +113,7 @@ pub(crate) fn get_time_path(
     from: std::time::Duration,
 ) -> IndexResult<Vec<Component>> {
     let from_timestamp = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp(from.as_secs_f64() as i64, from.subsec_nanos()),
+        NaiveDateTime::from_timestamp_opt(from.as_secs_f64() as i64, from.subsec_nanos()).unwrap(),
         Utc,
     );
     let mut time_path = vec![Component::from(


### PR DESCRIPTION
Replace deprecated chrono methods with their `_opt` equivalent, and unwrap() the Option. This preserves the same functionality as before with the new methods (panic if chrono method fails).