### PR TITLE
feat: support indexing AnyLinkableHash, not just EntryHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_time_index"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["jdeepee <joshuadparkin@gmail.com>"]
 edition = "2018"
 exclude = ["tests/*", "time-chunking.dna.workdir/*", "time-chunking.dna.gz", ".gitignore"]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
-use hdk::prelude::{EntryHash, ExternResult};
+use hdk::prelude::{AnyLinkableHash, ExternResult};
 
 pub trait IndexableEntry {
     ///Time that entry type this trait is implemented on should be indexed under
     fn entry_time(&self) -> DateTime<Utc>;
-    fn hash(&self) -> ExternResult<EntryHash>;
+    fn hash(&self) -> ExternResult<AnyLinkableHash>;
 }

--- a/tests/test_dna/zomes/test_zome_integrity/src/lib.rs
+++ b/tests/test_dna/zomes/test_zome_integrity/src/lib.rs
@@ -23,8 +23,8 @@ impl IndexableEntry for TestEntry {
         self.created
     }
 
-    fn hash(&self) -> ExternResult<EntryHash> {
-        hash_entry(self)
+    fn hash(&self) -> ExternResult<AnyLinkableHash> {
+        Ok(AnyLinkableHash::from(hash_entry(self)?))
     }
 }
 


### PR DESCRIPTION
Modify IndexableEntry trait to support AnyLinkableHash, not just EntryHash.

Note that this is a breaking change -- I bumped the minor version number to ensure downstream users can remain on the previous version.

**Todo**
- [ ] modify implementation of `get_links_and_load_for_time_span` to load into a provided AnyLinkableHash type